### PR TITLE
google-customization: fix the google-customization vendor calling path

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -15,17 +15,17 @@
 #
 
 ifeq ($(TARGET_INCLUDE_WIFI_EXT),true)
-$(call inherit-product, vendor/google-customization/interfaces/wifi_ext/wifi-ext.mk)
+$(call inherit-product, vendor/google/customization/interfaces/wifi_ext/wifi-ext.mk)
 endif
 
 ifeq ($(TARGET_FLATTEN_APEX),false)
 # Apex Namespace
-PRODUCT_SOONG_NAMESPACES += vendor/google-customization/apex/apex_images
+PRODUCT_SOONG_NAMESPACES += vendor/google/customization/apex/apex_images
 
 # Include package overlays
-PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/google-customization/overlay
-DEVICE_PACKAGE_OVERLAYS += vendor/google-customization/overlay
+PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/google/customization/overlay
+DEVICE_PACKAGE_OVERLAYS += vendor/google/customization/overlay
 endif
 
-$(call inherit-product, vendor/google-customization/product/config.mk)
-$(call inherit-product, vendor/google-customization/apex/apex.mk)
+$(call inherit-product, vendor/google/customization/product/config.mk)
+$(call inherit-product, vendor/google/customization/apex/apex.mk)


### PR DESCRIPTION
* [typo]
* product should be called from the directory name, not from the repository name