### PR TITLE
google-customization: fix the google-customization vendor path

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -15,17 +15,19 @@
 #
 
 ifeq ($(TARGET_INCLUDE_WIFI_EXT),true)
-$(call inherit-product, vendor/google-customization/interfaces/wifi_ext/wifi-ext.mk)
+$(call inherit-product, vendor/google/customization/interfaces/wifi_ext/wifi-ext.mk)
 endif
 
 ifeq ($(TARGET_FLATTEN_APEX),false)
+$(call inherit-product, vendor/google/customization/apex/apex.mk)
+
 # Apex Namespace
-PRODUCT_SOONG_NAMESPACES += vendor/google-customization/apex/apex_images
+PRODUCT_SOONG_NAMESPACES += vendor/google/customization/apex/apex_images
 
 # Include package overlays
-PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/google-customization/overlay
-DEVICE_PACKAGE_OVERLAYS += vendor/google-customization/overlay
+PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += vendor/google/customization/overlay
+DEVICE_PACKAGE_OVERLAYS += vendor/google/customization/overlay
 endif
 
-$(call inherit-product, vendor/google-customization/product/config.mk)
-$(call inherit-product, vendor/google-customization/apex/apex.mk)
+$(call inherit-product, vendor/google/customization/product/config.mk)
+$(call inherit-product, vendor/google/customization/apex/apex.mk)

--- a/interfaces/wifi_ext/wifi-ext.mk
+++ b/interfaces/wifi_ext/wifi-ext.mk
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-WIFI_EXT_PATH := vendor/google-customization/interfaces/wifi_ext
+WIFI_EXT_PATH := vendor/google/customization/interfaces/wifi_ext
 
 DEVICE_MANIFEST_FILE += $(WIFI_EXT_PATH)/manifest.xml
 


### PR DESCRIPTION
* this commit reverts 9d2fa6a0f07ed7d3dc3909e04530500bd18c87a0

* product should be called by the directory name, not by the repository name

Signed-off-by: bunnyyTheFreak <hsinghalk@yahoo.com>